### PR TITLE
always run `fifloader.py` in `install-openqa-post-rocky.sh` and update example `POST`

### DIFF
--- a/install-openqa-post-rocky.sh
+++ b/install-openqa-post-rocky.sh
@@ -27,8 +27,8 @@ sudo openqa-cli api -X POST isos \
   ARCH=x86_64 \
   DISTRI=rocky \
   FLAVOR=minimal-iso \
-  VERSION=8 \
-  GRUB="ip=dhcp bootdev=52:54:00:12:34:56 inst.waitfornet=300"
+  VERSION=8.4 \
+  BUILD="$(date +%Y%m%d.%H%M%S).0"
 
 if ! systemctl is-active openqa-worker@1 &> /dev/null; then
   sudo systemctl enable --now openqa-worker@1

--- a/install-openqa-post-rocky.sh
+++ b/install-openqa-post-rocky.sh
@@ -8,8 +8,8 @@ if [[ ! -d /var/lib/openqa/tests/rocky ]]; then
   sudo chown -R geekotest:geekotest rocky
   cd rocky
   sudo git checkout develop
-  sudo ./fifloader.py -l -c templates.fif.json templates-updates.fif.json
 fi
+cd /var/lib/openqa/tests/rocky && sudo ./fifloader.py -l -c templates.fif.json templates-updates.fif.json
 
 sudo mkdir -p /var/lib/openqa/share/factory/iso/fixed
 if [[ ! -f /var/lib/openqa/share/factory/iso/fixed/CHECKSUM ]]; then


### PR DESCRIPTION
## Description

Updates `install-openqa-post-rocky.sh` to close #6 and close #7.

## How Has This Been Tested?

- [x] Clean install of openQA dev system running in VirtualBox.
- [x] Rerun of `install-openqa-post-rocky.sh` on custom install of openQA dev system running in VirtualBox with mounted directories (from the host)...

```
[rocky@openqa-dev ~]$ mount -t vboxsf
rocky on /var/lib/openqa/share/tests/rocky type vboxsf (rw,relatime)
iso on /var/lib/openqa/share/factory/iso type vboxsf (rw,relatime)
hdd on /var/lib/openqa/share/factory/hdd type vboxsf (rw,relatime)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (install_software_raid also uses these needles and there's a new selection `select_root_already_selected` needle has to be fixed, tracked in #32 )
- [ ] Any dependent changes have been merged and published in downstream modules

This PR fixes #6 and fixes #7 and will close those issues on merge.