### PR TITLE
Add script to download aarch64 files

### DIFF
--- a/install-openqa-post-rocky-aarch64.sh
+++ b/install-openqa-post-rocky-aarch64.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+if [[ ! -d /var/lib/openqa/tests/rocky ]]; then
+  echo "Run install-openqa-post-rocky.sh first"
+  exit 1
+fi
+
+sudo mkdir -p /var/lib/openqa/share/factory/iso/fixed
+if [[ ! -f /var/lib/openqa/share/factory/iso/fixed/CHECKSUM_aarch64 ]]; then
+  cd /var/lib/openqa/share/factory/iso/fixed
+  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/aarch64/Rocky-8.4-aarch64-boot.iso
+  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/aarch64/Rocky-8.4-aarch64-minimal.iso
+  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/aarch64/Rocky-8.4-aarch64-dvd1.iso
+  sudo curl -C - download.rockylinux.org/pub/rocky/8/isos/aarch64/CHECKSUM  -o CHECKSUM_aarch64
+  shasum -a 256 --ignore-missing -c CHECKSUM_aarch64
+fi


### PR DESCRIPTION
# Description

This PR adds a script to download and verify the ISO files for aarch64 testing.

# How Has This Been Tested?

This PR was tested by installing openqa on an aarch64 machine (Ampere Altra):
```
sudo ./install-openqa.sh
# Login to create default API key before running next command
sudo ./install-openqa-post-rocky.sh
sudo ./install-openqa-post-rocky-aarch64.sh
# Verify images show up correctly in openqa UI
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules