### PR TITLE
Revert "Typo in dependency name"

### DIFF
--- a/install-openqa.sh
+++ b/install-openqa.sh
@@ -10,7 +10,7 @@ export release
 echo Installing OpenQA on Fedora
 echo Running on: "$release"
 
-pkgs=(git vim-enhanced openqa openqa-httpd openqa-worker fedora-messaging libguestfs-tools libguestfs-xfs python3-fedfind python3-libguestfs libvirt-daemon-config-network virt-install withlock postgresql-server perl-REST-Client)
+pkgs=(git vim-enhanced openqa openqa-httpd openqa-worker fedora-messaging guestfs-tools libguestfs-xfs python3-fedfind python3-libguestfs libvirt-daemon-config-network virt-install withlock postgresql-server perl-REST-Client)
 if ! rpm -q "${pkgs[@]}" &> /dev/null; then
   sudo dnf install -y "${pkgs[@]}"
 else


### PR DESCRIPTION
Reverts rocky-linux/OpenQA-Fedora-Installation#11

This wasn't a typo. The previous configuration was wrong for Fedora 34.

$ grep PRETTY /etc/os-release 
PRETTY_NAME="Fedora 34 (Thirty Four)"

$ dnf info libguestfs-tools
Error: No matching Packages to list

$ dnf info guestfs-tools
Installed Packages
Name         : guestfs-tools
<snip>

