### PR TITLE
FIX: make sure patch is deployed before first use

### DIFF
--- a/openqa-rocky-branding/deploy.sh
+++ b/openqa-rocky-branding/deploy.sh
@@ -4,14 +4,17 @@ set -x
 
 # deploy images
 rsync -a ./usr/share/openqa/assets/images /usr/share/openqa/assets/
+
+# we will use patch so make sure it is installed
+rpm -q patch || dnf -y install patch
+
 # patch assetpack.def
 patch --backup --forward --verbose /usr/share/openqa/assets/assetpack.def usr/share/openqa/assets/assetpack.def.patch
 
 # deploy rocky branding templates
 rsync -a ./usr/share/openqa/templates/webapi/branding/rocky /usr/share/openqa/templates/webapi/branding/
 
-# patch openQA index.html.ep template (requires install of patch package)
-rpm -q patch || dnf -y install patch
+# patch openQA index.html.ep template
 patch --backup --forward --verbose /usr/share/openqa/templates/webapi/main/index.html.ep usr/share/openqa/templates/webapi/main/index.html.ep.patch
 
 # backup / modify openqa.ini file


### PR DESCRIPTION
Discovered `patch` may be called before it is installed while deploying new openqa DEV system. Make sure `patch` is installed before first attempted use. Sorry folks...