### PR TITLE
update for Rocky 8.9 and optimize for re-run

### DIFF
--- a/install-openqa-post-rocky.sh
+++ b/install-openqa-post-rocky.sh
@@ -6,30 +6,53 @@ if [[ ! -d /var/lib/openqa/tests/rocky ]]; then
   cd /var/lib/openqa/tests/
   sudo git clone https://github.com/rocky-linux/os-autoinst-distri-rocky.git rocky
   sudo chown -R geekotest:geekotest rocky
-  cd rocky
-  git config --global --add safe.directory /var/lib/openqa/share/tests/rocky
-  sudo git checkout develop
 fi
-cd /var/lib/openqa/tests/rocky && sudo ./fifloader.py -l -c templates.fif.json templates-updates.fif.json
 
-sudo mkdir -p /var/lib/openqa/share/factory/iso/fixed
+# the rocky test area will be owned by and operated by geekotest user so deploy the
+# generated API key
+if [[ ! -d /var/lib/openqa/.config/openqa ]]; then
+  sudo mkdir -p /var/lib/openqa/.config/openqa
+  sudo cp /etc/openqa/client.conf /var/lib/openqa/.config/openqa/
+  sudo chown geekotest /var/lib/openqa/.config/openqa/client.conf
+fi
+
+if [[ -d /var/lib/openqa/tests/rocky ]]; then
+  cd /var/lib/openqa/tests/rocky
+  sudo -u geekotest git checkout develop
+  sudo -u geekotest ./fifloader.py -l -c templates.fif.json templates-updates.fif.json
+fi
+
+if [[ ! -d /var/lib/openqa/share/factory/iso/fixed ]]; then
+  sudo mkdir -p /var/lib/openqa/share/factory/iso/fixed
+fi
+
 if [[ ! -f /var/lib/openqa/share/factory/iso/fixed/CHECKSUM ]]; then
   cd /var/lib/openqa/share/factory/iso/fixed
-  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.7-x86_64-boot.iso
-  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.7-x86_64-minimal.iso
-  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.7-x86_64-dvd1.iso
   sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/CHECKSUM
+  if [[ ! -f /var/lib/openqa/share/factory/iso/fixed/Rocky-8.9-x86_64-boot.iso ]]; then
+    #sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.9-x86_64-boot.iso
+    echo "skipping boot_iso"
+  fi
+  if [[ ! -f /var/lib/openqa/share/factory/iso/fixed/Rocky-8.9-x86_64-minimal.iso ]]; then
+    sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.9-x86_64-minimal.iso
+  fi
+  if [[ ! -f /var/lib/openqa/share/factory/iso/fixed/Rocky-8.9-x86_64-dvd1.iso ]]; then
+    #sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.9-x86_64-dvd1.iso
+    echo "skipping dvd_iso"
+  fi
   shasum -a 256 --ignore-missing -c CHECKSUM
+  sudo /bin/rm -f CHECKSUM
 fi
 
 echo Now post a new job for Rocky :-\)
-sudo openqa-cli api -X POST isos \
-  ISO=Rocky-8.7-x86_64-minimal.iso \
+sudo -u geekotest openqa-cli api -X POST isos \
+  ISO=Rocky-8.9-x86_64-minimal.iso \
   ARCH=x86_64 \
   DISTRI=rocky \
   FLAVOR=minimal-iso \
-  VERSION=8.7 \
-  BUILD="$(date +%Y%m%d.%H%M%S).0"
+  VERSION=8.9 \
+  BUILD="$(date +%Y%m%d)-Rocky-8.9-x86_64.0" \
+  TEST=install_minimal
 
 echo Scheduled job should be started by worker!
 


### PR DESCRIPTION
This PR updates the `install-openqa-post-rocky.sh` script to support Rocky Linux 8.9 and makes other optimizations to allow rerun in the event a single step fails.

It is useful to configure the admin account in the DEV system for `sudo NOPASSWD` prior to running this script. Downloads of ISOs will typically result in expiration of the cached `sudo` credentials and subsequent `sudo` commands will require another authentication.

Also, `sudo` commands are changed to run updates of the rocky tests and post as the `geekotest` user instead of the `root` user. This is the way we manage the `rocky` directory in our production openQA system. Not strictly required but included for consistency.